### PR TITLE
Matrix Build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,6 +19,6 @@ jobs:
       run: OMR_TARGET="${{ matrix.device }}" OMR_FEED_SRC="master" ./build.sh
     - name: Upload artifacts
       uses: actions/upload-artifact@v2
-        with:
-          name: ${{ matrix.device }}
-          path: source/bin
+      with:
+        name: ${{ matrix.device }}
+        path: source/bin

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,24 @@
+# matrix build for openmptcprouter official hardware
+
+name: matrix
+on: [push, pull_request]
+
+  
+jobs:
+  build:
+    strategy:
+      matrix:
+        device: [bpi-r2, p2w_r619ac, rpi2, rpi4, wrt32x, espressobin, r2s, rpi3, wrt3200acm, x86, x86_64]                                                                 
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+    - uses: actions/checkout@v1
+    - name: Install dependencies
+      run: sudo apt-get -y install git-core build-essential libssl-dev libncurses5-dev unzip gawk zlib1g-dev busybox curl rsync gettext
+    - name: build images
+      run: OMR_TARGET="${{ matrix.device }}" OMR_FEED_SRC="master" ./build.sh
+    - name: Upload artifacts
+      uses: actions/upload-artifact@v2
+        with:
+          name: ${{ matrix.device }}
+          path: source/bin

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,4 +21,4 @@ jobs:
       uses: actions/upload-artifact@v2
       with:
         name: ${{ matrix.device }}
-        path: source/bin
+        path: ${{ matrix.device }}/source/bin

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Install dependencies
       run: sudo apt-get -y install git-core build-essential libssl-dev libncurses5-dev unzip gawk zlib1g-dev busybox curl rsync gettext
     - name: build images
-      run: OMR_TARGET="${{ matrix.device }}" OMR_FEED_SRC="master" ./build.sh
+      run: OMR_TARGET="${{ matrix.device }}" OMR_FEED_SRC="master" ./build.sh -j$(nproc)
     - name: Upload artifacts
       uses: actions/upload-artifact@v2
       with:

--- a/contributors/JacobGadikian.md
+++ b/contributors/JacobGadikian.md
@@ -1,0 +1,11 @@
+2020-09-12
+
+I hereby agree to the terms of the "OpenMPTCProuter Individual Contributor License Agreement", with MD5 checksum bc827a07eb93611d793ddb7c75083c00.
+
+I furthermore declare that I am authorized and able to make this agreement and sign this declaration.
+
+Signed,
+
+Jacob Gadikian
+
+https://github.com/faddat


### PR DESCRIPTION
This pull request adds a matrix build using GitHub actions. It automatically builds all of the supported devices found in the root of the repository.

I should note that two of the devices failed in this matrix build.

I think that having an automated build process like this one will help us to support a wider range of devices more easily and to ship images for those devices more easily as well.

Have a wonderful day!