### PR TITLE
Fix config for NanoPi R2S

### DIFF
--- a/config-r2s
+++ b/config-r2s
@@ -1,4 +1,4 @@
 CONFIG_TARGET_rockchip=y
 CONFIG_TARGET_rockchip_armv8=y
-CONFIG_TARGET_ramips_armv8_DEVICE_friendlyarm_nanopi-r2s=y
+CONFIG_TARGET_DEVICE_rockchip_armv8_DEVICE_friendlyarm_nanopi-r2s=y
 CONFIG_PACKAGE_kmod-6lowpan=y


### PR DESCRIPTION
In reference to commit: https://github.com/Ysurac/openmptcprouter/commit/ac362317dd92ddae3a4dbf0433ac95b3d3f9072b

The config file has the wrong architecture for the device.