### PR TITLE
Enable Shortcut Forwarding Engine support in kernel

### DIFF
--- a/5.4/target/linux/generic/hack-5.4/953-net-patch-linux-kernel-to-support-shortcut-fe.patch
+++ b/5.4/target/linux/generic/hack-5.4/953-net-patch-linux-kernel-to-support-shortcut-fe.patch
@@ -150,10 +150,11 @@
 +	bool "Enables kernel network stack path for Shortcut  Forwarding Engine
 --- a/net/netfilter/nf_conntrack_proto_tcp.c
 +++ b/net/netfilter/nf_conntrack_proto_tcp.c
-@@ -34,11 +34,19 @@
- /* Do not check the TCP window for incoming packets  */
- static int nf_ct_tcp_no_window_check __read_mostly = 1;
+@@ -32,6 +32,12 @@
+ #include <net/netfilter/ipv6/nf_conntrack_ipv6.h>
  
++int nf_ct_tcp_no_window_check __read_mostly = 1;
++
 +#ifdef CONFIG_SHORTCUT_FE
 +EXPORT_SYMBOL_GPL(nf_ct_tcp_no_window_check);
 +#endif


### PR DESCRIPTION
Add support for Shortcut Forwarding Engine in the kernel network stack.

Thanks for your contribution to OpenMPTCProuter!

You need to follow contributing rules.

Please remove this message before posting the pull request.
